### PR TITLE
adding documentation process

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -2,4 +2,15 @@
 sidebar_position: 1
 ---
 
-test
+# 変更プロセス
+
+下記のフォルダー内の変更は、　i18nの中の　en / jp　フォルダー
+内にあるページに変更を反映してください。
+
+docs -> (en/jp)/docusaurus-plugin-content-docs/current
+
+
+standard -> (en/jp)/docusaurus-plugin-content-standard/current
+
+
+blog ->  (en/jp)/docusaurus-plugin-content-blog

--- a/i18n/en/docusaurus-plugin-content-blog/authors.yml
+++ b/i18n/en/docusaurus-plugin-content-blog/authors.yml
@@ -1,5 +1,5 @@
 airinterface:
-  name: 福田ゆり
+  name: airinterface
   title: Engineering mind creative being
   url: https://github.com/airinterface
   image_url: https://github.com/airinterface.png

--- a/i18n/en/docusaurus-plugin-content-docs/current/intro.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/intro.md
@@ -2,4 +2,15 @@
 sidebar_position: 1
 ---
 
-test
+# Update process
+
+When you change any content in below folder, 
+copy content into i18n folders as well. 
+
+docs -> i18n/(en/jp)/docusaurus-plugin-content-docs/current
+
+
+standard -> i18n/(en/jp)/docusaurus-plugin-content-standard/current
+
+
+blog ->  i18n/(en/jp)/docusaurus-plugin-content-blog

--- a/i18n/ja/docusaurus-plugin-content-docs/current/intro.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/intro.md
@@ -2,4 +2,15 @@
 sidebar_position: 1
 ---
 
-test
+# 変更プロセス
+
+下記のフォルダー内の変更は、　i18nの中の　en / jp　フォルダー
+内にあるページに変更を反映してください。
+
+docs -> (en/jp)/docusaurus-plugin-content-docs/current
+
+
+standard -> (en/jp)/docusaurus-plugin-content-standard/current
+
+
+blog ->  (en/jp)/docusaurus-plugin-content-blog

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,13 +16,6 @@ function HomepageHeader() {
           {siteConfig.title}
         </Heading>
         <p className="hero__subtitle">{siteConfig.tagline}</p>
-        <div className={styles.buttons}>
-          <Link
-            className="button button--secondary button--lg"
-            to="/docs/intro">
-            Docusaurus Tutorial - 5min ⏱️
-          </Link>
-        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
1.　メインページの Doc へのボタンをなくしました。
![Screenshot_2024-06-03_13-29-27](https://github.com/MicroEdgeCerts/microedgecerts.github.io/assets/2448586/f76cce07-82a9-40d4-b252-bb9d5c015fba)


3. Documentationに関係するフォルダーの説明を追加しました。
![Screenshot_2024-06-03_13-29-19](https://github.com/MicroEdgeCerts/microedgecerts.github.io/assets/2448586/57712815-4ca3-4198-9251-bc4ffcbc318b)
